### PR TITLE
Added templated enqueue function to telem interface to limit code reuse

### DIFF
--- a/lib/interfaces/include/TelemetryInterface.h
+++ b/lib/interfaces/include/TelemetryInterface.h
@@ -71,11 +71,14 @@ public:
     );
 
     /* Enqueue outbound telemetry CAN messages */    
-    void enqueue_CAN_mcu_pedal_readings();
-    void enqueue_CAN_mcu_load_cells();
-    void enqueue_CAN_mcu_front_potentiometers();
-    void enqueue_CAN_mcu_rear_potentiometers();
-    void enqueue_CAN_mcu_analog_readings();
+    // void enqueue_CAN_mcu_pedal_readings();
+    // void enqueue_CAN_mcu_load_cells();
+    // void enqueue_CAN_mcu_front_potentiometers();
+    // void enqueue_CAN_mcu_rear_potentiometers();
+    // void enqueue_CAN_mcu_analog_readings();
+
+    template<typename T>
+    void enqueue_CAN(T& can_msg, uint32_t  id);
 
     /* Tick at 50Hz to send CAN */
     void tick(

--- a/lib/interfaces/src/TelemetryInterface.cpp
+++ b/lib/interfaces/src/TelemetryInterface.cpp
@@ -1,68 +1,5 @@
 #include "TelemetryInterface.h"
 
-/* Send CAN messages */
-// Pedal readings
-void TelemetryInterface::enqueue_CAN_mcu_pedal_readings() {
-    
-    CAN_message_t msg;
-    mcu_pedal_readings_.write(msg.buf);
-    msg.id = ID_MCU_PEDAL_READINGS;
-    msg.len = sizeof(mcu_pedal_readings_);
-    uint8_t buf[sizeof(CAN_message_t)];
-    memmove(buf, &msg, sizeof(msg));
-
-    msg_queue_->push_back(buf, sizeof(CAN_message_t));
-}
-// Loadcell readings
-void TelemetryInterface::enqueue_CAN_mcu_load_cells() {
-    
-    CAN_message_t msg;
-    mcu_load_cells_.write(msg.buf);
-    msg.id = ID_MCU_LOAD_CELLS;
-    msg.len = sizeof(mcu_load_cells_);
-    uint8_t buf[sizeof(CAN_message_t)];
-    memmove(buf, &msg, sizeof(msg));
-
-    msg_queue_->push_back(buf, sizeof(CAN_message_t));
-}
-// Suspension potentiometers
-// Front
-void TelemetryInterface::enqueue_CAN_mcu_front_potentiometers() {
-    
-    CAN_message_t msg;
-    mcu_front_potentiometers_.write(msg.buf);
-    msg.id = ID_MCU_FRONT_POTS;
-    msg.len = sizeof(mcu_front_potentiometers_);
-    uint8_t buf[sizeof(CAN_message_t)];
-    memmove(buf, &msg, sizeof(msg));
-
-    msg_queue_->push_back(buf, sizeof(CAN_message_t));
-}
-// Rear
-void TelemetryInterface::enqueue_CAN_mcu_rear_potentiometers() {
-    
-    CAN_message_t msg;
-    mcu_rear_potentiometers_.write(msg.buf);
-    msg.id = ID_MCU_REAR_POTS;
-    msg.len = sizeof(mcu_rear_potentiometers_);
-    uint8_t buf[sizeof(CAN_message_t)];
-    memmove(buf, &msg, sizeof(msg));
-
-    msg_queue_->push_back(buf, sizeof(CAN_message_t));
-}
-// Analog sensor readings
-void TelemetryInterface::enqueue_CAN_mcu_analog_readings() {
-
-    CAN_message_t msg;
-    mcu_analog_readings_.write(msg.buf);
-    msg.id = ID_MCU_ANALOG_READINGS;
-    msg.len = sizeof(mcu_analog_readings_);
-    uint8_t buf[sizeof(CAN_message_t)];
-    memmove(buf, &msg, sizeof(msg));
-
-    msg_queue_->push_back(buf, sizeof(CAN_message_t));
-}
-
 /* Update CAN messages */
 // Main loop
 // MCP3208 returns structure
@@ -75,6 +12,8 @@ void TelemetryInterface::update_pedal_readings_CAN_msg(const AnalogConversion_s 
     mcu_pedal_readings_.set_accelerator_pedal_2(accel2.raw);
     mcu_pedal_readings_.set_brake_pedal_1(brake1.raw);
     mcu_pedal_readings_.set_brake_pedal_2(brake2.raw);
+
+    enqueue_CAN<MCU_pedal_readings>(mcu_pedal_readings_, ID_MCU_PEDAL_READINGS);
 }
 // MCP3204 returns structure
 void TelemetryInterface::update_load_cells_CAN_msg(const AnalogConversion_s &lc_fl,
@@ -84,6 +23,8 @@ void TelemetryInterface::update_load_cells_CAN_msg(const AnalogConversion_s &lc_
     mcu_load_cells_.set_FR_load_cell(lc_fr.raw);
     // mcu_load_cells_.set_RL_load_cell(lc_fl.raw);
     // mcu_load_cells_.set_RR_load_cell(lc_fr.raw);    
+
+    enqueue_CAN<MCU_load_cells>(mcu_load_cells_, ID_MCU_LOAD_CELLS);
 }
 // MCP3204 returns structure
 void TelemetryInterface::update_potentiometers_CAN_msg(const AnalogConversion_s &pots_fl,
@@ -95,6 +36,9 @@ void TelemetryInterface::update_potentiometers_CAN_msg(const AnalogConversion_s 
     // do sth with mcu_rear_potentiometers_
     // mcu_rear_potentiometers_.set_pot4(pots_rl.raw);
     // mcu_rear_potentiometers_.set_pot6(pots_rr.raw);
+
+    enqueue_CAN<MCU_front_potentiometers>(mcu_front_potentiometers_, ID_MCU_FRONT_POTS);
+    // enqueue_CAN<MCU_rear_potentiometers>(mcu_rear_potentiometers_, ID_MCU_REAR_POTS);
 }
 // SteeringDual and MCP3208 return structures
 void TelemetryInterface::update_analog_readings_CAN_msg(const SteeringEncoderConversion_s &steer1,
@@ -107,6 +51,87 @@ void TelemetryInterface::update_analog_readings_CAN_msg(const SteeringEncoderCon
     mcu_analog_readings_.set_steering_2(steer2.raw);
     mcu_analog_readings_.set_hall_effect_current(current.raw - reference.raw);
     mcu_analog_readings_.set_glv_battery_voltage(glv.raw);
+
+    enqueue_CAN<MCU_analog_readings>(mcu_analog_readings_, ID_MCU_ANALOG_READINGS);
+}
+
+/* Send CAN messages */
+// Pedal readings
+// void TelemetryInterface::enqueue_CAN_mcu_pedal_readings() {
+    
+//     CAN_message_t msg;
+//     mcu_pedal_readings_.write(msg.buf);
+//     msg.id = ID_MCU_PEDAL_READINGS;
+//     msg.len = sizeof(mcu_pedal_readings_);
+//     uint8_t buf[sizeof(CAN_message_t)];
+//     memmove(buf, &msg, sizeof(msg));
+
+//     msg_queue_->push_back(buf, sizeof(CAN_message_t));
+// }
+// // Loadcell readings
+// void TelemetryInterface::enqueue_CAN_mcu_load_cells() {
+    
+//     CAN_message_t msg;
+//     mcu_load_cells_.write(msg.buf);
+//     msg.id = ID_MCU_LOAD_CELLS;
+//     msg.len = sizeof(mcu_load_cells_);
+//     uint8_t buf[sizeof(CAN_message_t)];
+//     memmove(buf, &msg, sizeof(msg));
+
+//     msg_queue_->push_back(buf, sizeof(CAN_message_t));
+// }
+// Suspension potentiometers
+// Front
+// void TelemetryInterface::enqueue_CAN_mcu_front_potentiometers() {
+    
+//     CAN_message_t msg;
+//     mcu_front_potentiometers_.write(msg.buf);
+//     msg.id = ID_MCU_FRONT_POTS;
+//     msg.len = sizeof(mcu_front_potentiometers_);
+//     uint8_t buf[sizeof(CAN_message_t)];
+//     memmove(buf, &msg, sizeof(msg));
+
+//     msg_queue_->push_back(buf, sizeof(CAN_message_t));
+// }
+// // Rear
+// void TelemetryInterface::enqueue_CAN_mcu_rear_potentiometers() {
+    
+//     CAN_message_t msg;
+//     mcu_rear_potentiometers_.write(msg.buf);
+//     msg.id = ID_MCU_REAR_POTS;
+//     msg.len = sizeof(mcu_rear_potentiometers_);
+//     uint8_t buf[sizeof(CAN_message_t)];
+//     memmove(buf, &msg, sizeof(msg));
+
+//     msg_queue_->push_back(buf, sizeof(CAN_message_t));
+// }
+// // Analog sensor readings
+// void TelemetryInterface::enqueue_CAN_mcu_analog_readings() {
+
+    
+
+//     CAN_message_t msg;
+//     mcu_analog_readings_.write(msg.buf);
+//     msg.id = ID_MCU_ANALOG_READINGS;
+//     msg.len = sizeof(mcu_analog_readings_);
+//     uint8_t buf[sizeof(CAN_message_t)];
+//     memmove(buf, &msg, sizeof(msg));
+
+//     msg_queue_->push_back(buf, sizeof(CAN_message_t));
+// }
+
+template<typename T>
+void TelemetryInterface::enqueue_CAN(T& msg_class, uint32_t  id) {
+    
+    CAN_message_t msg;
+    msg_class.write(msg.buf);
+    msg.id = id;
+    msg.len = sizeof(msg_class);
+    uint8_t buf[sizeof(CAN_message_t)];
+    memmove(buf, &msg, sizeof(CAN_message_t));
+
+    msg_queue_->push_back(buf, sizeof(CAN_message_t));
+
 }
 
 /* Tick SysClock */
@@ -120,22 +145,22 @@ void TelemetryInterface::tick(const AnalogConversionPacket_s<8> &adc1,
                                   adc1.conversions[channels_.accel2_channel],
                                   adc1.conversions[channels_.brake1_channel],
                                   adc1.conversions[channels_.brake2_channel]);
-    enqueue_CAN_mcu_pedal_readings();
+    // enqueue_CAN_mcu_pedal_readings();
     // Analog readings
     update_analog_readings_CAN_msg(encoder,
                                    adc1.conversions[channels_.analog_steering_channel],
                                    adc1.conversions[channels_.current_channel],
                                    adc1.conversions[channels_.current_ref_channel],
                                    adc1.conversions[channels_.glv_sense_channel]);
-    enqueue_CAN_mcu_analog_readings();
+    // enqueue_CAN_mcu_analog_readings();
     // Load cells
     update_load_cells_CAN_msg(adc2.conversions[channels_.loadcell_fl_channel],
                               adc3.conversions[channels_.loadcell_fr_channel]);
-    enqueue_CAN_mcu_load_cells();
+    // enqueue_CAN_mcu_load_cells();
     // Pots
     update_potentiometers_CAN_msg(adc2.conversions[channels_.pots_fl_channel],
                                   adc3.conversions[channels_.pots_fr_channel]);
-    enqueue_CAN_mcu_front_potentiometers();
+    // enqueue_CAN_mcu_front_potentiometers();
     // enqueue_CAN_mcu_rear_potentiometers();
 
 }


### PR DESCRIPTION
This PR templates a function in the telem interface to allow us to pack and push messages onto the circular buffer in one line, removing the amount of reused code.

I will do the embedded tests I could not run tonight on Sunday, and then the commented code can be removed and this can be merged

closes #40 