### PR TITLE
Load cell vectoring

### DIFF
--- a/include/MCU_rev15_defs.h
+++ b/include/MCU_rev15_defs.h
@@ -47,4 +47,18 @@ const int BRAKE2_MAX_THRESH = 2150;
 const float BRKAE_ACTIVATION_PERCENTAGE = 0.05;
 const float BRAKE_MECH_THRESH = 0.55;
 
+// Load Cell Defs to convert raw to lbs
+// lbs = (scale)*raw + offset
+
+const float LOADCELL_FL_SCALE = 0.0553;
+const float LOADCELL_FL_OFFSET = 15.892;
+
+const float LOADCELL_FR_SCALE = 0.0512;
+const float LOADCELL_FR_OFFSET = 17.196;
+
+const float LOADCELL_RL_SCALE = 0.1147;
+const float LOADCELL_RL_OFFSET = 21.842;
+
+const float LOADCELL_RR_SCALE = 0.0588;
+const float LOADCELL_RR_OFFSET = 19.576;
 #endif /* __MCU15_H__ */

--- a/lib/interfaces/include/DashboardInterface.h
+++ b/lib/interfaces/include/DashboardInterface.h
@@ -137,7 +137,7 @@ public:
     /* getter for the mark button */
     bool specialButtonPressed();
     /* getter for the torque button (does not currently exist on dash ) */
-    bool torqueButtonPressed();
+    bool torqueModeButtonPressed();
     /* getter for the inverter reset button (clears error codes ) */
     bool inverterResetButtonPressed();
     /* getter for the launch control button */

--- a/lib/interfaces/src/DashboardInterface.cpp
+++ b/lib/interfaces/src/DashboardInterface.cpp
@@ -99,10 +99,9 @@ DialMode_e DashboardInterface::getDialMode() {return _data.dial_mode;}
 
 bool DashboardInterface::startButtonPressed() {return _data.button.start;}
 bool DashboardInterface::specialButtonPressed() {return _data.button.mark;}
-bool DashboardInterface::torqueButtonPressed() {return _data.button.mode;}
+bool DashboardInterface::torqueModeButtonPressed() {return _data.button.torque_mode;}
 bool DashboardInterface::inverterResetButtonPressed() {return _data.button.mc_cycle;}
 bool DashboardInterface::launchControlButtonPressed() {return _data.button.launch_ctrl;}
-bool DashboardInterface::torqueLoadingButtonPressed() {return _data.button.torque_mode;}
 bool DashboardInterface::nightModeButtonPressed() {return _data.button.led_dimmer;}
 bool DashboardInterface::leftShifterButtonPressed() {return _data.button.left_shifter;}
 bool DashboardInterface::rightShifterButtonPressed() {return _data.button.right_shifter;}

--- a/lib/systems/include/DrivetrainSystem.h
+++ b/lib/systems/include/DrivetrainSystem.h
@@ -10,7 +10,7 @@
 struct DrivetrainCommand_s
 {
     float speeds_rpm[NUM_MOTORS];
-    float torqueSetpoints[NUM_MOTORS];
+    float torqueSetpoints[NUM_MOTORS]; // FIXME: misnomer. This represents the magnitude of the torque the inverter can command to reach the commanded speed setpoint
 };
 
 struct DrivetrainDynamicReport_s

--- a/lib/systems/include/TorqueControllerMux.h
+++ b/lib/systems/include/TorqueControllerMux.h
@@ -27,7 +27,7 @@ private:
     std::unordered_map<DialMode_e, TorqueController_e> dialModeMap_ = {
         {DialMode_e::MODE_0, TorqueController_e::TC_SAFE_MODE},
         {DialMode_e::MODE_1, TorqueController_e::TC_SAFE_MODE},
-        {DialMode_e::MODE_2, TorqueController_e::TC_NO_CONTROLLER},
+        {DialMode_e::MODE_2, TorqueController_e::TC_LOAD_CELL_VECTORING},
         {DialMode_e::MODE_3, TorqueController_e::TC_NO_CONTROLLER},
         {DialMode_e::MODE_4, TorqueController_e::TC_NO_CONTROLLER},
         {DialMode_e::MODE_5, TorqueController_e::TC_NO_CONTROLLER},
@@ -37,9 +37,10 @@ private:
         {TorqueLimit_e::TCMUX_MID_TORQUE, 15.0},
         {TorqueLimit_e::TCMUX_FULL_TORQUE, 20.0}
     };
-    DrivetrainCommand_s controllerCommands_[static_cast<int>(TorqueController_e::TC_NUM_CONTROLLERS)];
+    TorqueControllerOutput_s controllerOutputs_[static_cast<int>(TorqueController_e::TC_NUM_CONTROLLERS)];
     TorqueControllerNone torqueControllerNone_;
     TorqueControllerSimple torqueControllerSimple_;
+    TorqueControllerLoadCellVectoring torqueControllerLoadCellVectoring_;
     TorqueController_e muxMode_ = TorqueController_e::TC_NO_CONTROLLER;
     DrivetrainCommand_s drivetrainCommand_;
     TorqueLimit_e torqueLimit_ = TorqueLimit_e::TCMUX_LOW_TORQUE;
@@ -48,8 +49,9 @@ private:
 public:
 // Constructors
     TorqueControllerMux()
-    : torqueControllerNone_(controllerCommands_[static_cast<int>(TorqueController_e::TC_NO_CONTROLLER)])
-    , torqueControllerSimple_(controllerCommands_[static_cast<int>(TorqueController_e::TC_SAFE_MODE)]) {}
+    : torqueControllerNone_(controllerOutputs_[static_cast<int>(TorqueController_e::TC_NO_CONTROLLER)])
+    , torqueControllerSimple_(controllerOutputs_[static_cast<int>(TorqueController_e::TC_SAFE_MODE)])
+    , torqueControllerLoadCellVectoring_(controllerOutputs_[static_cast<int>(TorqueController_e::TC_LOAD_CELL_VECTORING)]) {}
 // Functions
     void tick(
         const SysTick_s& tick,

--- a/lib/systems/include/TorqueControllers.h
+++ b/lib/systems/include/TorqueControllers.h
@@ -18,11 +18,22 @@ const float AMK_MAX_RPM = (13.4 * METERS_PER_SECOND_TO_RPM); // 30mph
 const float AMK_MAX_TORQUE = 20.0; // TODO: update this with the true value
 const float MAX_REGEN_TORQUE = 10.0;
 
+const DrivetrainCommand_s TC_COMMAND_NO_TORQUE = {
+    .speeds_rpm = {0.0, 0.0, 0.0, 0.0},
+    .torqueSetpoints= {0.0, 0.0, 0.0, 0.0}
+};
+
+struct TorqueControllerOutput_s {
+    DrivetrainCommand_s command;
+    bool ready;
+};
+
 enum TorqueController_e
 {
     TC_NO_CONTROLLER = 0,
     TC_SAFE_MODE = 1,
-    TC_NUM_CONTROLLERS = 2,
+    TC_LOAD_CELL_VECTORING = 2,
+    TC_NUM_CONTROLLERS = 3,
 };
 
 /// @brief If a command fed through this function exceeds the specified power limit, all torques will be scaled down equally
@@ -57,14 +68,11 @@ public:
 class TorqueControllerNone : public TorqueController<TC_NO_CONTROLLER>
 {
 private:
-    DrivetrainCommand_s data_ = {
-        .speeds_rpm = {0.0, 0.0, 0.0, 0.0},
-        .torqueSetpoints= {0.0, 0.0, 0.0, 0.0}
-    };
 public:
-    TorqueControllerNone(DrivetrainCommand_s& writeout)
+    TorqueControllerNone(TorqueControllerOutput_s& writeout)
     {
-        writeout = data_;
+        writeout.command = TC_COMMAND_NO_TORQUE;
+        writeout.ready = true;
     };
 };
 
@@ -72,18 +80,81 @@ public:
 class TorqueControllerSimple : public TorqueController<TC_SAFE_MODE>
 {
 private:
-    DrivetrainCommand_s& writeout_;
-    DrivetrainCommand_s data_;
+    TorqueControllerOutput_s& writeout_;
     float frontTorqueScale_ = 1.0;
     float rearTorqueScale_ = 1.0;
 public:
-    TorqueControllerSimple(DrivetrainCommand_s& writeout, float rearTorqueScale)
+    TorqueControllerSimple(TorqueControllerOutput_s& writeout, float rearTorqueScale)
     : writeout_(writeout),
     frontTorqueScale_(2.0 - rearTorqueScale),
-    rearTorqueScale_(rearTorqueScale) {}
-    TorqueControllerSimple(DrivetrainCommand_s& writeout) : TorqueControllerSimple(writeout, 1.0) {}
+    rearTorqueScale_(rearTorqueScale) 
+    {
+        writeout_.command = TC_COMMAND_NO_TORQUE;
+        writeout_.ready = true;
+    }
+    TorqueControllerSimple(TorqueControllerOutput_s& writeout) : TorqueControllerSimple(writeout, 1.0) {}
 
     void tick(const SysTick_s& tick, const PedalsSystemData_s& pedalsData, float torqueLimit);
+};
+
+class TorqueControllerLoadCellVectoring : public TorqueController<TC_LOAD_CELL_VECTORING>
+{
+private:
+    TorqueControllerOutput_s& writeout_;
+    float frontTorqueScale_ = 1.0;
+    float rearTorqueScale_ = 1.0;
+    /*
+    FIR filter designed with
+    http://t-filter.appspot.com
+
+    sampling frequency: 100 Hz
+
+    * 0 Hz - 10 Hz
+    gain = 1
+    desired ripple = 5 dB
+    actual ripple = 1.7659949026015025 dB
+
+    * 40 Hz - 50 Hz
+    gain = 0
+    desired attenuation = -40 dB
+    actual attenuation = -47.34009380570117 dB
+    */
+    const static int numFIRTaps_ = 5;
+    float FIRTaps_[numFIRTaps_] = {
+        0.07022690881526232,
+        0.27638313122745306,
+        0.408090001549378,
+        0.27638313122745306,
+        0.07022690881526232
+    };
+    int FIRCircBufferHead = 0; // index of the latest sample in the raw buffer 
+    float loadCellForcesRaw_[4][numFIRTaps_] = {};
+    float loadCellForcesFiltered_[4] = {};
+    // Some checks that can disable the controller
+    const int errorCountThreshold_ = 25;
+    int loadCellsErrorCounter_[4] = {};
+    bool FIRSaturated_ = false;
+    bool ready_ = false;
+public:
+    TorqueControllerLoadCellVectoring(TorqueControllerOutput_s& writeout, float rearTorqueScale)
+    : writeout_(writeout),
+    frontTorqueScale_(2.0 - rearTorqueScale),
+    rearTorqueScale_(rearTorqueScale) 
+    {
+        writeout_.command = TC_COMMAND_NO_TORQUE;
+        writeout_.ready = false;
+    }
+    TorqueControllerLoadCellVectoring(TorqueControllerOutput_s& writeout) : TorqueControllerLoadCellVectoring(writeout, 1.0) {}
+
+    void tick(
+        const SysTick_s& tick, 
+        const PedalsSystemData_s& pedalsData, 
+        float torqueLimit,
+        const AnalogConversion_s& flLoadCellData,
+        const AnalogConversion_s& frLoadCellData,
+        const AnalogConversion_s& rlLoadCellData,
+        const AnalogConversion_s& rrLoadCellData
+    );
 };
 
 #endif /* __TORQUECONTROLLERS_H__ */

--- a/lib/systems/src/TorqueControllerMux.cpp
+++ b/lib/systems/src/TorqueControllerMux.cpp
@@ -16,6 +16,7 @@ void TorqueControllerMux::tick(
 {
     // Tick all torque controllers
     torqueControllerSimple_.tick(tick, pedalsData, torqueLimitMap_[torqueLimit_]);
+    torqueControllerLoadCellVectoring_.tick(tick, pedalsData, torqueLimitMap_[torqueLimit_], loadFLData, loadFRData, loadRLData, loadRRData);
     // Tick torque button logic at 50hz
     if (tick.triggers.trigger50)
     {

--- a/lib/systems/src/TorqueControllers.cpp
+++ b/lib/systems/src/TorqueControllers.cpp
@@ -38,40 +38,143 @@ void TorqueControllerSimple::tick(const SysTick_s &tick, const PedalsSystemData_
             // Positive torque request
             torqueRequest = accelRequest * AMK_MAX_TORQUE;
 
-            // data_.speeds_rpm[FL] = accelRequest * AMK_MAX_RPM;
-            // data_.speeds_rpm[FR] = accelRequest * AMK_MAX_RPM;
-            // data_.speeds_rpm[RL] = accelRequest * AMK_MAX_RPM;
-            // data_.speeds_rpm[RR] = accelRequest * AMK_MAX_RPM;
-            data_.speeds_rpm[FL] = AMK_MAX_RPM;
-            data_.speeds_rpm[FR] = AMK_MAX_RPM;
-            data_.speeds_rpm[RL] = AMK_MAX_RPM;
-            data_.speeds_rpm[RR] = AMK_MAX_RPM;
+            // writeout_.command.speeds_rpm[FL] = accelRequest * AMK_MAX_RPM;
+            // writeout_.command.speeds_rpm[FR] = accelRequest * AMK_MAX_RPM;
+            // writeout_.command.speeds_rpm[RL] = accelRequest * AMK_MAX_RPM;
+            // writeout_.command.speeds_rpm[RR] = accelRequest * AMK_MAX_RPM;
+            writeout_.command.speeds_rpm[FL] = AMK_MAX_RPM;
+            writeout_.command.speeds_rpm[FR] = AMK_MAX_RPM;
+            writeout_.command.speeds_rpm[RL] = AMK_MAX_RPM;
+            writeout_.command.speeds_rpm[RR] = AMK_MAX_RPM;
 
-            data_.torqueSetpoints[FL] = torqueRequest * frontTorqueScale_;
-            data_.torqueSetpoints[FR] = torqueRequest * frontTorqueScale_;
-            data_.torqueSetpoints[RL] = torqueRequest * rearTorqueScale_;
-            data_.torqueSetpoints[RR] = torqueRequest * rearTorqueScale_;
+            writeout_.command.torqueSetpoints[FL] = torqueRequest * frontTorqueScale_;
+            writeout_.command.torqueSetpoints[FR] = torqueRequest * frontTorqueScale_;
+            writeout_.command.torqueSetpoints[RL] = torqueRequest * rearTorqueScale_;
+            writeout_.command.torqueSetpoints[RR] = torqueRequest * rearTorqueScale_;
         }
         else
         {
             // Negative torque request
             torqueRequest = MAX_REGEN_TORQUE * accelRequest * -1.0;
 
-            data_.speeds_rpm[FL] = 0.0;
-            data_.speeds_rpm[FR] = 0.0;
-            data_.speeds_rpm[RL] = 0.0;
-            data_.speeds_rpm[RR] = 0.0;
+            writeout_.command.speeds_rpm[FL] = 0.0;
+            writeout_.command.speeds_rpm[FR] = 0.0;
+            writeout_.command.speeds_rpm[RL] = 0.0;
+            writeout_.command.speeds_rpm[RR] = 0.0;
 
-            data_.torqueSetpoints[FL] = torqueRequest;
-            data_.torqueSetpoints[FR] = torqueRequest;
-            data_.torqueSetpoints[RL] = torqueRequest;
-            data_.torqueSetpoints[RR] = torqueRequest;
+            writeout_.command.torqueSetpoints[FL] = torqueRequest;
+            writeout_.command.torqueSetpoints[FR] = torqueRequest;
+            writeout_.command.torqueSetpoints[RL] = torqueRequest;
+            writeout_.command.torqueSetpoints[RR] = torqueRequest;
         }
 
         // Apply the torque limit
-        TCPosTorqueLimit(data_, torqueLimit);
+        TCPosTorqueLimit(writeout_.command, torqueLimit);
 
-        writeout_ = data_;
+    }
+}
 
+// TorqueControllerLoadCellVectoring
+
+void TorqueControllerLoadCellVectoring::tick(
+    const SysTick_s& tick, 
+    const PedalsSystemData_s& pedalsData, 
+    float torqueLimit,
+    const AnalogConversion_s& flLoadCellData,
+    const AnalogConversion_s& frLoadCellData,
+    const AnalogConversion_s& rlLoadCellData,
+    const AnalogConversion_s& rrLoadCellData
+)
+{
+    // Calculate torque commands at 100hz
+    if (tick.triggers.trigger100)
+    {
+        // Apply FIR filter to load cell data
+        loadCellForcesRaw_[0][FIRCircBufferHead] = flLoadCellData.conversion;
+        loadCellForcesRaw_[1][FIRCircBufferHead] = frLoadCellData.conversion;
+        loadCellForcesRaw_[2][FIRCircBufferHead] = rlLoadCellData.conversion;
+        loadCellForcesRaw_[3][FIRCircBufferHead] = rrLoadCellData.conversion;
+
+        for (int i = 0; i < 4; i++)
+        {
+            loadCellForcesFiltered_[i] = 0.0f;
+            for (int FIROffset = 0; FIROffset < numFIRTaps_; FIROffset++)
+            {
+                int index = (FIRCircBufferHead + FIROffset) % numFIRTaps_;
+                loadCellForcesFiltered_[i] += loadCellForcesRaw_[i][index] * FIRTaps_[FIROffset];
+            }
+        }
+        FIRCircBufferHead = (FIRCircBufferHead + 1) % numFIRTaps_;
+        if (FIRCircBufferHead == numFIRTaps_ - 1)
+            FIRSaturated_ = true;
+
+        // Do sanity checks on raw data
+        loadCellsErrorCounter_[0] = flLoadCellData.raw != 4095 && flLoadCellData.status != AnalogSensorStatus_e::ANALOG_SENSOR_CLAMPED ? 0 : loadCellsErrorCounter_[0] + 1;
+        loadCellsErrorCounter_[1] = frLoadCellData.raw != 4095 && frLoadCellData.status != AnalogSensorStatus_e::ANALOG_SENSOR_CLAMPED ? 0 : loadCellsErrorCounter_[1] + 1;
+        loadCellsErrorCounter_[2] = rlLoadCellData.raw != 4095 && rlLoadCellData.status != AnalogSensorStatus_e::ANALOG_SENSOR_CLAMPED ? 0 : loadCellsErrorCounter_[2] + 1;
+        loadCellsErrorCounter_[3] = rrLoadCellData.raw != 4095 && rrLoadCellData.status != AnalogSensorStatus_e::ANALOG_SENSOR_CLAMPED ? 0 : loadCellsErrorCounter_[3] + 1;
+        ready_ = FIRSaturated_ 
+            && loadCellsErrorCounter_[0] < errorCountThreshold_ 
+            && loadCellsErrorCounter_[1] < errorCountThreshold_ 
+            && loadCellsErrorCounter_[2] < errorCountThreshold_ 
+            && loadCellsErrorCounter_[3] < errorCountThreshold_;
+
+        writeout_.ready = ready_;
+
+        if (ready_)
+        {
+            // Calculate total normal force
+            float sumNormalForce = 0.0f;
+            for (int i = 0; i < 4; i++)
+            {
+                sumNormalForce += loadCellForcesFiltered_[i];
+            }
+
+            // Both pedals are not pressed and no implausibility has been detected
+            // accelRequest goes between 1.0 and -1.0
+            float accelRequest = pedalsData.accelPercent - pedalsData.regenPercent;
+            float torquePool;
+            float torqueRequest;
+
+            if (accelRequest >= 0.0)
+            {
+                // Positive torque request
+                // NOTE: using "torquePool" here instead of torqueRequest for legibility
+                torquePool = accelRequest * AMK_MAX_TORQUE * 4;
+
+                writeout_.command.speeds_rpm[FL] = AMK_MAX_RPM;
+                writeout_.command.speeds_rpm[FR] = AMK_MAX_RPM;
+                writeout_.command.speeds_rpm[RL] = AMK_MAX_RPM;
+                writeout_.command.speeds_rpm[RR] = AMK_MAX_RPM;
+
+                writeout_.command.torqueSetpoints[FL] = torquePool * frontTorqueScale_ * loadCellForcesFiltered_[0] / sumNormalForce;
+                writeout_.command.torqueSetpoints[FR] = torquePool * frontTorqueScale_ * loadCellForcesFiltered_[1] / sumNormalForce;
+                writeout_.command.torqueSetpoints[RL] = torquePool * rearTorqueScale_ * loadCellForcesFiltered_[2] / sumNormalForce;
+                writeout_.command.torqueSetpoints[RR] = torquePool * rearTorqueScale_ * loadCellForcesFiltered_[3] / sumNormalForce;
+            }
+            else
+            {
+                // Negative torque request
+                // No load cell vectoring on regen
+                torqueRequest = MAX_REGEN_TORQUE * accelRequest * -1.0;
+
+                writeout_.command.speeds_rpm[FL] = 0.0;
+                writeout_.command.speeds_rpm[FR] = 0.0;
+                writeout_.command.speeds_rpm[RL] = 0.0;
+                writeout_.command.speeds_rpm[RR] = 0.0;
+
+                writeout_.command.torqueSetpoints[FL] = torqueRequest;
+                writeout_.command.torqueSetpoints[FR] = torqueRequest;
+                writeout_.command.torqueSetpoints[RL] = torqueRequest;
+                writeout_.command.torqueSetpoints[RR] = torqueRequest;
+            }
+
+            // Apply the torque limit
+            TCPosTorqueLimit(writeout_.command, torqueLimit);
+        }
+        else
+        {
+            writeout_.command = TC_COMMAND_NO_TORQUE;
+        }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -296,7 +296,7 @@ void tick_all_systems(const SysTick_s &current_system_tick)
         (const AnalogConversion_s){},                         // RL load cell reading. TODO: get data from rear load cells
         (const AnalogConversion_s){},                         // RR load cell reading. TODO: get data from rear load cells
         dashboard.getDialMode(),
-        dashboard.torqueButtonPressed());
+        dashboard.torqueModeButtonPressed());
 }
 
 

--- a/src/main_minimal.cpp
+++ b/src/main_minimal.cpp
@@ -314,5 +314,5 @@ void tick_all_systems(const SysTick_s &current_system_tick)
         sab_interface.rlLoadCell.convert(),  // RL load cell reading. TODO: get data from rear load cells
         sab_interface.rrLoadCell.convert(), // RR load cell reading. TODO: get data from rear load cells
         dashboard.getDialMode(),
-        dashboard.torqueButtonPressed());
+        dashboard.torqueModeButtonPressed());
 }

--- a/src/main_minimal.cpp
+++ b/src/main_minimal.cpp
@@ -60,10 +60,10 @@ TelemetryInterface telem_interface(&CAN3_txBuffer, {MCU15_ACCEL1_CHANNEL, MCU15_
                                                     MCU15_FL_POTS_CHANNEL, MCU15_FR_POTS_CHANNEL, MCU15_FL_LOADCELL_CHANNEL, MCU15_FR_LOADCELL_CHANNEL,
                                                     MCU15_STEERING_CHANNEL, MCU15_CUR_POS_SENSE_CHANNEL, MCU15_CUR_NEG_SENSE_CHANNEL, MCU15_GLV_SENSE_CHANNEL});
 SABInterface sab_interface(
-    1.0,
-    0.0,
-    1.0,
-    0.0 // TODO: add tuning values
+    1.0, // RL Scale
+    0.0, // RL Offset (Migos)
+    1.0, // RR Scale
+    0.0 //  RR Offset
 );
 
 // /* Inverter Interface Type */
@@ -137,6 +137,12 @@ void setup()
     a1.setChannelOffset(MCU15_ACCEL2_CHANNEL, -ACCEL2_MIN_THRESH);
     a1.setChannelOffset(MCU15_BRAKE1_CHANNEL, -BRAKE1_MIN_THRESH);
     a1.setChannelOffset(MCU15_BRAKE2_CHANNEL, -BRAKE2_MIN_THRESH);
+
+    a3.setChannelScale(MCU15_FL_LOADCELL_CHANNEL,1/*Todo*/);
+    a3.setChannelScale(MCU15_FR_LOADCELL_CHANNEL,0/*Todo*/);
+
+    a3.setChannelOffset(MCU15_FL_LOADCELL_CHANNEL,1/*Todo*/);
+    a3.setChannelOffset(MCU15_FR_LOADCELL_CHANNEL,0/*Todo*/);
 
     Serial.begin(115200);
 
@@ -305,8 +311,8 @@ void tick_all_systems(const SysTick_s &current_system_tick)
         steering_system.getSteeringSystemData(),
         a2.get().conversions[MCU15_FL_LOADCELL_CHANNEL], // FL load cell reading. TODO: fix index
         a3.get().conversions[MCU15_FR_LOADCELL_CHANNEL], // FR load cell reading. TODO: fix index
-        (const AnalogConversion_s){},                    // RL load cell reading. TODO: get data from rear load cells
-        (const AnalogConversion_s){},                    // RR load cell reading. TODO: get data from rear load cells
+        sab_interface.rlLoadCell.convert(),  // RL load cell reading. TODO: get data from rear load cells
+        sab_interface.rrLoadCell.convert(), // RR load cell reading. TODO: get data from rear load cells
         dashboard.getDialMode(),
         dashboard.torqueButtonPressed());
 }

--- a/src/main_minimal.cpp
+++ b/src/main_minimal.cpp
@@ -60,10 +60,10 @@ TelemetryInterface telem_interface(&CAN3_txBuffer, {MCU15_ACCEL1_CHANNEL, MCU15_
                                                     MCU15_FL_POTS_CHANNEL, MCU15_FR_POTS_CHANNEL, MCU15_FL_LOADCELL_CHANNEL, MCU15_FR_LOADCELL_CHANNEL,
                                                     MCU15_STEERING_CHANNEL, MCU15_CUR_POS_SENSE_CHANNEL, MCU15_CUR_NEG_SENSE_CHANNEL, MCU15_GLV_SENSE_CHANNEL});
 SABInterface sab_interface(
-    1.0, // RL Scale
-    0.0, // RL Offset (Migos)
-    1.0, // RR Scale
-    0.0 //  RR Offset
+    LOADCELL_RL_SCALE, // RL Scale
+    LOADCELL_RL_OFFSET, // RL Offset (Migos)
+    LOADCELL_RR_SCALE, // RR Scale
+    LOADCELL_RR_OFFSET //  RR Offset
 );
 
 // /* Inverter Interface Type */
@@ -138,11 +138,11 @@ void setup()
     a1.setChannelOffset(MCU15_BRAKE1_CHANNEL, -BRAKE1_MIN_THRESH);
     a1.setChannelOffset(MCU15_BRAKE2_CHANNEL, -BRAKE2_MIN_THRESH);
 
-    a3.setChannelScale(MCU15_FL_LOADCELL_CHANNEL,1/*Todo*/);
-    a3.setChannelScale(MCU15_FR_LOADCELL_CHANNEL,0/*Todo*/);
+    a3.setChannelScale(MCU15_FL_LOADCELL_CHANNEL,LOADCELL_FL_SCALE/*Todo*/);
+    a3.setChannelScale(MCU15_FR_LOADCELL_CHANNEL,LOADCELL_FR_SCALE/*Todo*/);
 
-    a3.setChannelOffset(MCU15_FL_LOADCELL_CHANNEL,1/*Todo*/);
-    a3.setChannelOffset(MCU15_FR_LOADCELL_CHANNEL,0/*Todo*/);
+    a3.setChannelOffset(MCU15_FL_LOADCELL_CHANNEL,LOADCELL_FL_OFFSET/*Todo*/);
+    a3.setChannelOffset(MCU15_FR_LOADCELL_CHANNEL,LOADCELL_FR_OFFSET/*Todo*/);
 
     Serial.begin(115200);
 

--- a/test/test_interfaces/dashboard_interface_test.h
+++ b/test/test_interfaces/dashboard_interface_test.h
@@ -45,7 +45,7 @@ void test_dashboard_unpacking_can_message(void)
 
       TEST_ASSERT_EQUAL(current_state.start_button, dash_interface.startButtonPressed() );
       TEST_ASSERT_EQUAL(current_state.mark_button, dash_interface.specialButtonPressed() );
-      TEST_ASSERT_EQUAL(current_state.mode_button , dash_interface.torqueButtonPressed() );
+      TEST_ASSERT_EQUAL(current_state.mode_button , dash_interface.torqueModeButtonPressed() );
       TEST_ASSERT_EQUAL(current_state.motor_controller_cycle_button, dash_interface.inverterResetButtonPressed() );
       TEST_ASSERT_EQUAL(current_state.launch_ctrl_button , dash_interface.launchControlButtonPressed() );
       TEST_ASSERT_EQUAL(current_state.torque_mode_button , dash_interface.torqueLoadingButtonPressed() );


### PR DESCRIPTION
Load cell torque controller

- Distributes torque to wheels proportionally based on sensed normal force
- Load cell values are FIR filtered
- - This requires hardware aliasing filters to work properly
- - Load cell AnalogChannels should be configured with clamping to enforce rationality checking
- - i.e., `.clamp = true`, `.clampLow = // something negative. we don't care about lower bound`, `.clampHigh = 1000 // choose a rational upper bound on the amount of force we expect to sense on a single load cel`

Added `ready` to TorqueController outputs.

- TCMux ingests `ready` to determine whether a controller can be selected and whether to fall back to safe mode