### PR TITLE
Power, torque, and negative speedpoint limit

### DIFF
--- a/lib/systems/include/PhysicalParameters.h
+++ b/lib/systems/include/PhysicalParameters.h
@@ -6,4 +6,7 @@ const float WHEEL_DIAMETER =            0.4064; // meters
 const float RPM_TO_METERS_PER_SECOND =  WHEEL_DIAMETER * 3.1415 / GEARBOX_RATIO / 60.0;
 const float METERS_PER_SECOND_TO_RPM = 1.0 / RPM_TO_METERS_PER_SECOND;
 
+const float RPM_TO_RAD_PER_SECOND = 2 * 3.1415 / 60.0;
+const float RAD_PER_SECOND_TO_RPM = 1 / RPM_TO_RAD_PER_SECOND;
+
 #endif /* __PHYSICALPARAMETERS_H__ */

--- a/lib/systems/include/TorqueControllerMux.h
+++ b/lib/systems/include/TorqueControllerMux.h
@@ -111,6 +111,8 @@ public:
 
     void applyTorqueLimit(DrivetrainCommand_s* command);
 
+    void applyPosSpeedLimit(DrivetrainCommand_s* command);
+
     TorqueControllerBase* activeController()
     {
         // check to make sure that there is actually a controller

--- a/lib/systems/include/TorqueControllerMux.h
+++ b/lib/systems/include/TorqueControllerMux.h
@@ -92,6 +92,7 @@ public:
         bool dashboardTorqueModeButtonPressed,
         const vector_nav &vn_data, 
         float wheel_angle_rad);
+
     const DrivetrainCommand_s &getDrivetrainCommand()
     {
         return drivetrainCommand_;

--- a/lib/systems/include/TorqueControllerMux.h
+++ b/lib/systems/include/TorqueControllerMux.h
@@ -2,6 +2,8 @@
 #define __TORQUECTRLMUX_H__
 
 #include <unordered_map>
+#include <cmath>
+
 #include "TorqueControllers.h"
 #include "DrivetrainSystem.h"
 #include "PedalsSystem.h"
@@ -29,7 +31,7 @@ private:
     std::unordered_map<TorqueLimit_e, float> torqueLimitMap_ = {
         {TorqueLimit_e::TCMUX_LOW_TORQUE, 10.0},
         {TorqueLimit_e::TCMUX_MID_TORQUE, 15.0},
-        {TorqueLimit_e::TCMUX_FULL_TORQUE, 21.4}
+        {TorqueLimit_e::TCMUX_FULL_TORQUE, AMK_MAX_TORQUE}
     };
 
     TorqueController_e muxMode_ = TorqueController_e::TC_NO_CONTROLLER;
@@ -94,14 +96,21 @@ public:
     {
         return drivetrainCommand_;
     };
+    
     const TorqueLimit_e &getTorqueLimit()
     {
         return torqueLimit_;
     };
+
     const float getMaxTorque()
     {
         return torqueLimitMap_[torqueLimit_];
     }
+
+    void applyPowerLimit(DrivetrainCommand_s* command);
+
+    void applyTorqueLimit(DrivetrainCommand_s* command);
+
     TorqueControllerBase* activeController()
     {
         // check to make sure that there is actually a controller

--- a/lib/systems/include/TorqueControllers.h
+++ b/lib/systems/include/TorqueControllers.h
@@ -15,6 +15,10 @@
 #include "TorqueControllersData.h"
 #include "PID_TV.h"
 
+/* CONTROLLER CONSTANTS */
+
+const float MAX_POWER_LIMIT = 63.0; // max mechanical power limit in KW
+
 /* MOTOR CONSTANTS */
 
 const float AMK_MAX_RPM = 20000;
@@ -119,22 +123,6 @@ template <TorqueController_e TorqueControllerType>
 class TorqueController : public TorqueControllerBase
 {
 protected:
-
-    void TCPowerLimitScaleDown(
-        DrivetrainCommand_s &command,
-        const DrivetrainDynamicReport_s &drivetrainData,
-        float powerLimit)
-    {
-        // TODO
-        // probably requires AMS interface
-    }
-    void TCPosTorqueLimit(DrivetrainCommand_s &command, float torqueLimit)
-    {
-        for (int i = 0; i < NUM_MOTORS; i++)
-        {
-            command.torqueSetpoints[i] = std::min(command.torqueSetpoints[i], torqueLimit);
-        }
-    }
 
 public:
 };

--- a/lib/systems/include/TorqueControllers.h
+++ b/lib/systems/include/TorqueControllers.h
@@ -17,7 +17,7 @@
 
 /* CONTROLLER CONSTANTS */
 
-const float MAX_POWER_LIMIT = 63.0; // max mechanical power limit in KW
+const float MAX_POWER_LIMIT = 63000.0; // max mechanical power limit in KW
 
 /* MOTOR CONSTANTS */
 

--- a/lib/systems/src/TorqueControllerMux.cpp
+++ b/lib/systems/src/TorqueControllerMux.cpp
@@ -2,6 +2,8 @@
 #include "Utility.h"
 #include "PhysicalParameters.h"
 
+#include <stdio.h>
+
 void TorqueControllerMux::tick(
     const SysTick_s &tick,
     const DrivetrainDynamicReport_s &drivetrainData,
@@ -154,12 +156,17 @@ void TorqueControllerMux::applyTorqueLimit(DrivetrainCommand_s* command)
     }
     avg_torque /= NUM_MOTORS;
     
+    printf("max torque: %.2f\n", max_torque);
+    printf("avg torque: %.2f\n", avg_torque);
     // if this is greather than the torque limit, scale down
     if (avg_torque > max_torque) {
         // get the scale of avg torque above max torque
         float scale = avg_torque / max_torque;
         // divide by scale to lower avg below max torque
-        for (int i = 0; i < NUM_MOTORS; i++) { command->torqueSetpoints[i] /= scale; }
+        printf("scale: %.2f\n", scale);
+        for (int i = 0; i < NUM_MOTORS; i++) {
+            command->torqueSetpoints[i] /= scale;
+        }
     }
 
 }

--- a/lib/systems/src/TorqueControllers.cpp
+++ b/lib/systems/src/TorqueControllers.cpp
@@ -50,9 +50,6 @@ void TorqueControllerSimple::tick(const SysTick_s &tick, const PedalsSystemData_
             writeout_.command.torqueSetpoints[RL] = torqueRequest * rearRegenTorqueScale_;
             writeout_.command.torqueSetpoints[RR] = torqueRequest * rearRegenTorqueScale_;
         }
-
-        // Apply the torque limit
-        TCPosTorqueLimit(writeout_.command, torqueLimit);
     }
 }
 
@@ -145,9 +142,6 @@ void TorqueControllerLoadCellVectoring::tick(
                 writeout_.command.torqueSetpoints[RL] = torqueRequest;
                 writeout_.command.torqueSetpoints[RR] = torqueRequest;
             }
-
-            // Apply the torque limit
-            TCPosTorqueLimit(writeout_.command, torqueLimit);
         }
         else
         {

--- a/test/test_systems/torque_controller_mux_test.h
+++ b/test/test_systems/torque_controller_mux_test.h
@@ -316,6 +316,43 @@ TEST(TorqueControllerMuxTesting, test_power_limit) {
     
 }
 
+TEST(TorqueControllerMuxTesting, test_torque_limit) {
+    TorqueControllerMux mux = TorqueControllerMux();
+    DrivetrainCommand_s drive_command;
+
+    for (int i = 0; i < 4; i++) {
+        drive_command.speeds_rpm[i] = 500.0f;
+        drive_command.torqueSetpoints[i] = 10.0f;
+    }
+
+    drive_command.torqueSetpoints[0] = 5;
+
+    mux.applyTorqueLimit(&drive_command);
+
+    ASSERT_EQ(drive_command.torqueSetpoints[0], 5.0f);
+    ASSERT_EQ(drive_command.torqueSetpoints[1], 10.0f);
+    ASSERT_EQ(drive_command.torqueSetpoints[2], 10.0f);
+    ASSERT_EQ(drive_command.torqueSetpoints[3], 10.0f);
+
+    for (int i = 0; i < 4; i++) {
+        drive_command.speeds_rpm[i] = 500.0f;
+        drive_command.torqueSetpoints[i] = 20.0f;
+    }
+    drive_command.torqueSetpoints[0] = 5;
+
+    mux.applyTorqueLimit(&drive_command);
+
+    ASSERT_LT(drive_command.torqueSetpoints[0], 3.5f);
+    ASSERT_LT(drive_command.torqueSetpoints[1], 12.5f);
+    ASSERT_LT(drive_command.torqueSetpoints[2], 12.5f);
+    ASSERT_LT(drive_command.torqueSetpoints[3], 12.5f);
+
+    printf("torque 1: %.2f\n", drive_command.torqueSetpoints[0]);
+    printf("torque 2: %.2f\n", drive_command.torqueSetpoints[1]);
+    printf("torque 3: %.2f\n", drive_command.torqueSetpoints[2]);
+    printf("torque 4: %.2f\n", drive_command.torqueSetpoints[3]);
+}
+
 TEST(TorqueControllerMuxTesting, test_simple_launch_controller) {
      SysClock clock = SysClock();
     SysTick_s cur_tick;

--- a/test/test_systems/torque_controller_mux_test.h
+++ b/test/test_systems/torque_controller_mux_test.h
@@ -287,6 +287,35 @@ TEST(TorqueControllerMuxTesting, test_speed_delta_prevents_mode_change)
     }    
 }
 
+TEST(TorqueControllerMuxTesting, test_power_limit) {
+    TorqueControllerMux mux = TorqueControllerMux();
+    DrivetrainCommand_s drive_command;
+
+    for (int i = 0; i < 4; i++) {
+        drive_command.speeds_rpm[i] = 500.0f;
+        drive_command.torqueSetpoints[i] = 10.0f;
+    }
+
+    mux.applyPowerLimit(&drive_command);
+
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(drive_command.speeds_rpm[i], 500.0f);
+        ASSERT_EQ(drive_command.torqueSetpoints[i], 10.0f);
+    }
+
+    for (int i = 0; i < 4; i++) {
+        drive_command.speeds_rpm[i] = 20000.0f;
+        drive_command.torqueSetpoints[i] = 21.0f;
+    }
+
+    mux.applyPowerLimit(&drive_command);
+
+    for (int i = 0; i < 4; i++) {
+        ASSERT_LT(drive_command.torqueSetpoints[i], 7.6); // hardcoded value based on online calculator
+    }
+    
+}
+
 TEST(TorqueControllerMuxTesting, test_simple_launch_controller) {
      SysClock clock = SysClock();
     SysTick_s cur_tick;


### PR DESCRIPTION
This PR replaces and completes the limiting functions that were present in the torque controllers.

These have been placed in the TCMUX since they should be applied to all controllers and all drivetrain requests.

The Power limit is a simple powerlimit akin to the one run on HT07. When calculated mechanical power is above the predetermined 63kw mechanical power limit it will scale down all motor torques to be below the 63kw limit while preserving ratios as determined by the torque controllers.

The torque limit works in a similar manner but takes the average torque value across all motors. This will effectively limit the torque output of our motors so that the average torque of all motors at any point in time is the same as the dashboard/ecu torque limit.

The negative speedtest limit function just takes the max of speed setpoint values above 0, preventing the car from commanding backwards motion