### PR TITLE
Update slip launch logic

### DIFF
--- a/lib/systems/include/TorqueControllers.h
+++ b/lib/systems/include/TorqueControllers.h
@@ -33,7 +33,7 @@ const float DEFAULT_LAUNCH_RATE = 11.76;
 const int16_t DEFAULT_LAUNCH_SPEED_TARGET = 1500;
 
 const float DEFAULT_SLIP_RATIO = 0.2f;
-const float const_accel_time = 1500; // time to use launch speed target in ms
+const float const_accel_time = 100; // time to use launch speed target in ms
 
 const float launch_ready_accel_threshold = .1;
 const float launch_ready_brake_threshold = .2;

--- a/lib/systems/src/TorqueControllers.cpp
+++ b/lib/systems/src/TorqueControllers.cpp
@@ -283,23 +283,22 @@ void TorqueControllerSlipLaunch::calc_launch_algo(const vector_nav* vn_data) {
             uint32_t ms_since_launch = (current_millis - time_of_launch);
             // accelerate at constant speed for a period of time to get body velocity up
             // may want to make this the ht07 launch algo
-            if(ms_since_launch < const_accel_time){
-                launch_speed_target = DEFAULT_LAUNCH_SPEED_TARGET;
+            
+            // makes sure that the car launches at the target launch speed
+            launch_speed_target = std::max(launch_speed_target, DEFAULT_LAUNCH_SPEED_TARGET);
 
-            } else {
-
-                /*
-                New slip-ratio based launch algorithm by Luke Chen. The basic idea
-                is to always be pushing the car a certain 'slip_ratio_' faster than
-                the car is currently going, theoretically always keeping the car in slip
-                */
-                // m/s
-                float new_speed_target = (1 + slip_ratio_) * (vn_data->velocity_x);
-                // rpm
-                new_speed_target *= METERS_PER_SECOND_TO_RPM;
-                launch_speed_target = std::max(launch_speed_target, new_speed_target);
-
-            }
+            /*
+            New slip-ratio based launch algorithm by Luke Chen. The basic idea
+            is to always be pushing the car a certain 'slip_ratio_' faster than
+            the car is currently going, theoretically always keeping the car in slip
+            */
+            // m/s
+            float new_speed_target = (1 + slip_ratio_) * (vn_data->velocity_x);
+            // rpm
+            new_speed_target *= METERS_PER_SECOND_TO_RPM;
+            // makes sure the car target speed never goes lower than prev. target
+            // allows for the vn to 'spool' up and us to get reliable vx data
+            launch_speed_target = std::max(launch_speed_target, new_speed_target);
 
 }
 

--- a/lib/systems/src/TorqueControllers.cpp
+++ b/lib/systems/src/TorqueControllers.cpp
@@ -285,7 +285,7 @@ void TorqueControllerSlipLaunch::calc_launch_algo(const vector_nav* vn_data) {
             // may want to make this the ht07 launch algo
             
             // makes sure that the car launches at the target launch speed
-            launch_speed_target = std::max(launch_speed_target, DEFAULT_LAUNCH_SPEED_TARGET);
+            launch_speed_target = std::max(launch_speed_target, (float)DEFAULT_LAUNCH_SPEED_TARGET);
 
             /*
             New slip-ratio based launch algorithm by Luke Chen. The basic idea


### PR DESCRIPTION
Removes the delay to transition from initial launch speed to vn launch control.

Just need to test this on car