### PR TITLE
add steering system tests. Fix steering failure case

### DIFF
--- a/test/test_systems/main.cpp
+++ b/test/test_systems/main.cpp
@@ -5,8 +5,7 @@
 #include "torque_controller_mux_test.h"
 #include "drivetrain_system_test.h"
 #include "safety_system_test.h"
-// #include "test_CASE.h"
-// #include "param_system_test.h"
+#include "test_CASE.h"
 #include "steering_system_test.h"
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Added steering test cases to cover all expected operating modes. Fixed case where if primary sensor was AWOL and secondary sensor was clamped, system would take 0 degree report from the error'd primary senesor.