### PR TITLE
Fixed platformio.ini reference to shared_firmware_interfaces

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -61,7 +61,7 @@ lib_deps =
   ${common.lib_deps_shared}
   Nanopb
   SPI
-  https://github.com/hytech-racing/shared_firmware_interfaces.git#shared_types
+  https://github.com/hytech-racing/shared_firmware_interfaces.git
   https://github.com/tonton81/FlexCAN_T4
   https://github.com/ssilverman/QNEthernet#v0.26.0
   https://github.com/RCMast3r/hytech_can#testing_new_inv_ids
@@ -84,7 +84,7 @@ lib_deps =
     https://github.com/tonton81/FlexCAN_T4#b928bcb
     https://github.com/RCMast3r/hytech_can#4ffbba4
     https://github.com/hytech-racing/HT_params/releases/download/2024-05-07T06_59_33/ht_eth_pb_lib.tar.gz
-    https://github.com/hytech-racing/shared_firmware_interfaces.git#feature/thermistor-template
+    https://github.com/hytech-racing/shared_firmware_interfaces.git
     https://github.com/hytech-racing/shared_firmware_systems.git#af96a63
     https://github.com/RCMast3r/spi_libs#2214fee
     https://github.com/hytech-racing/HT_CAN/releases/download/127/can_lib.tar.gz


### PR DESCRIPTION
Platformio.ini was referencing the shared_types branch of shared_firmware_interfaces. Since I merged that branch into main, then I need to update this dependency.